### PR TITLE
dotenv: enable to load environment variables from .env when running main process and pytest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # ignoring target
+.env
 __pycache__/
 beta_cord.py
 config/*.*

--- a/Pipfile
+++ b/Pipfile
@@ -12,6 +12,7 @@ mplfinance = "*"
 urllib3 = ">=1.26.5"
 pandas = ">=1.2.0"
 oandapyV20 = "*"
+python-dotenv = "*"
 
 [dev-packages]
 moto = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "a758d2a8b854fa8a9a4181fc22bfe72f40e9b6383ebc4e564590bd5e1e5b53c9"
+            "sha256": "a3c604e3766dd5f42e5ad34e3ee5a1b83c1fbc5031d23c95dcf1e8cc8effef65"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -267,6 +267,14 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.8.2"
+        },
+        "python-dotenv": {
+            "hashes": [
+                "sha256:aae25dc1ebe97c420f50b81fb0e5c949659af713f31fdb63c749ca68748f34b1",
+                "sha256:f521bc2ac9a8e03c736f62911605c5d83970021e3fa95b37d769e2bbbe9b6172"
+            ],
+            "index": "pypi",
+            "version": "==0.19.0"
         },
         "pytz": {
             "hashes": [

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,9 @@
 ###### Requirements without Version Specifiers ######
 # General
 boto3
-numpy
 matplotlib
+numpy
+python-dotenv
 # pymongo
 requests
 # scipy # trendline生成時には必要

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,13 @@
+import os
+from dotenv import load_dotenv
 import pytest
+
+
+@pytest.fixture(scope='session', autouse=True)
+def load_env() -> None:
+    dotenv_path: str = os.path.join('./.env')
+    load_dotenv(dotenv_path)
+    yield
 
 
 @pytest.fixture(scope='session')
@@ -30,16 +39,16 @@ def dummy_raw_open_trades():
     return {
         'trades': [
             {
-            'instrument': 'DE30_EUR',
-            'financing': '0.0000',
-            'openTime': '2016-10-28T14:28:05.231759081Z',
-            'initialUnits': '10',
-            'currentUnits': '10',
-            'price': '10678.3',
-            'unrealizedPL': '136.0000',
-            'realizedPL': '0.0000',
-            'state': 'OPEN',
-            'id': '2315'
+                'instrument': 'DE30_EUR',
+                'financing': '0.0000',
+                'openTime': '2016-10-28T14:28:05.231759081Z',
+                'initialUnits': '10',
+                'currentUnits': '10',
+                'price': '10678.3',
+                'unrealizedPL': '136.0000',
+                'realizedPL': '0.0000',
+                'state': 'OPEN',
+                'id': '2315'
             }
         ],
         'lastTransactionID': '2317'


### PR DESCRIPTION
This pull request completes one of the tasks on #136, but doesn't complete all of them.