### PR TITLE
fix #192: update README to clarify serverless framework v2 is necessary at this time

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ You have to introduce following packages before start developing.
 - awscli
 - node
     - serverless
+    ```bash
+    $ npm -g install serverless@2
+    ```
 - DynamoDB Local (and, though it is optional, DynamoDB Admin)
 
 ## Deployment


### PR DESCRIPTION
#192 